### PR TITLE
feat: add helper function for message attribute building

### DIFF
--- a/cloud/amazon/helpers.py
+++ b/cloud/amazon/helpers.py
@@ -1,10 +1,10 @@
-from typing import Dict, Union
+from typing import Mapping, Union
 
 DataType = Union[str, bytes, int, float]
-MessageAttributes = Dict[str, Dict[str, DataType]]
+MessageAttributes = Mapping[str, Mapping[str, DataType]]
 
 
-def build_attributes(data: Dict[str, DataType]) -> MessageAttributes:
+def build_attributes(data: Mapping[str, DataType]) -> MessageAttributes:
     attrs = {}
 
     for key, value in data.items():

--- a/cloud/amazon/helpers.py
+++ b/cloud/amazon/helpers.py
@@ -1,0 +1,22 @@
+from typing import Dict, Union
+
+DataType = Union[str, bytes, int, float]
+MessageAttributes = Dict[str, Dict[str, DataType]]
+
+
+def build_attributes(data: Dict[str, DataType]) -> MessageAttributes:
+    attrs = {}
+
+    for key, value in data.items():
+        if isinstance(value, str):
+            attr = {"StringValue": value, "DataType": "String"}
+        elif isinstance(value, bytes):
+            attr = {"BinaryValue": value, "DataType": "Binary"}
+        elif isinstance(value, (int, float)):
+            attr = {"StringValue": value, "DataType": "Number"}
+        else:
+            raise TypeError(f"{value} of type {type(value).__name__} is not supported")
+
+        attrs[key] = attr
+
+    return attrs

--- a/cloud/amazon/helpers.py
+++ b/cloud/amazon/helpers.py
@@ -13,7 +13,7 @@ def build_attributes(data: Mapping[str, DataType]) -> MessageAttributes:
         elif isinstance(value, bytes):
             attr = {"BinaryValue": value, "DataType": "Binary"}
         elif isinstance(value, (int, float)):
-            attr = {"StringValue": value, "DataType": "Number"}
+            attr = {"StringValue": str(value), "DataType": "Number"}
         else:
             raise TypeError(f"{value} of type {type(value).__name__} is not supported")
 

--- a/tests/amazon/test_helpers.py
+++ b/tests/amazon/test_helpers.py
@@ -1,0 +1,23 @@
+import unittest
+
+from cloud.amazon import helpers
+
+
+class TestBuildAttributes(unittest.TestCase):
+    def test_build_attributes(self):
+        data = {"foo": "bar", "bar": b"baz", "baz": 42}
+        expected = {
+            "foo": {"StringValue": data["foo"], "DataType": "String"},
+            "bar": {"BinaryValue": data["bar"], "DataType": "Binary"},
+            "baz": {"StringValue": data["baz"], "DataType": "Number"},
+        }
+        attributes = helpers.build_attributes(data)
+
+        self.assertEqual(attributes, expected)
+
+    def test_build_attributes_with_invalid_data(self):
+        data = {"foo": None}
+        error = "^None of type NoneType is not supported$"
+
+        with self.assertRaisesRegex(TypeError, error):
+            helpers.build_attributes(data)  # type: ignore

--- a/tests/amazon/test_helpers.py
+++ b/tests/amazon/test_helpers.py
@@ -9,7 +9,7 @@ class TestBuildAttributes(unittest.TestCase):
         expected = {
             "foo": {"StringValue": data["foo"], "DataType": "String"},
             "bar": {"BinaryValue": data["bar"], "DataType": "Binary"},
-            "baz": {"StringValue": data["baz"], "DataType": "Number"},
+            "baz": {"StringValue": str(data["baz"]), "DataType": "Number"},
         }
         attributes = helpers.build_attributes(data)
 


### PR DESCRIPTION
### Contain
- [x] New feature
- [x] Tests

### Details
This commit introduces a new module `helpers.py`, which contains a function `build_attributes` to construct message attributes from a given dictionary. The function supports multiple data types, including strings, bytes, and numbers. Additionally, the commit includes a new test suite `test_helpers.py` that verifies the correct functionality of `build_attributes` with valid data and checks for appropriate error handling when unsupported data types are provided.
