### PR TITLE
chore: bump version from 0.4.0 to 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "cloudtoolbox"
-version = "0.4.0"
+version = "0.5.0"
 description = "Toolbox for the cloud."
 readme = { file = "README.md", content-type = "text/markdown" }
 authors = [{ name = "Dotz Developers", email = "devs-dotz@dotz.com" }]


### PR DESCRIPTION
### Contain
- [x] Build/CI/CD

### Details
Updated the project version in the `pyproject.toml` file to reflect the new release. This change marks the transition from version 0.4.0 to 0.5.0 for the "cloudtoolbox" project, indicating new features or improvements have been made since the last version.
