### PR TITLE
feat: change publish method signatures for consistency and clarity

### DIFF
--- a/cloud/amazon/sns.py
+++ b/cloud/amazon/sns.py
@@ -1,14 +1,24 @@
 import uuid
-from typing import Any
+from typing import Any, Mapping, Optional
 
 import boto3
+
+from cloud.amazon import helpers
 
 
 class Publisher:
     def __init__(self, *args: Any, **kwargs: Any):
         self.client = boto3.client("sns", *args, **kwargs)
 
-    def publish(self, recipient: str, message: str, group: str = "", **attrs: Any) -> str:
+    def publish(
+        self,
+        recipient: str,
+        message: str,
+        /,
+        *,
+        group: str = "",
+        attrs: Optional[Mapping[str, Any]] = None,
+    ) -> str:
         kwargs = {}
 
         if group:
@@ -16,7 +26,7 @@ class Publisher:
             kwargs["MessageDeduplicationId"] = str(uuid.uuid4())
 
         if attrs:
-            kwargs["MessageAttributes"] = attrs
+            kwargs["MessageAttributes"] = helpers.build_attributes(attrs)
 
         response = self.client.publish(TargetArn=recipient, Message=message, **kwargs)
         return response["MessageId"]

--- a/cloud/amazon/sqs.py
+++ b/cloud/amazon/sqs.py
@@ -1,14 +1,24 @@
 import uuid
-from typing import Any
+from typing import Any, Mapping, Optional
 
 import boto3
+
+from cloud.amazon import helpers
 
 
 class Publisher:
     def __init__(self, *args: Any, **kwargs: Any):
         self.client = boto3.client("sqs", *args, **kwargs)
 
-    def publish(self, recipient: str, message: str, group: str = "", **attrs: Any) -> str:
+    def publish(
+        self,
+        recipient: str,
+        message: str,
+        /,
+        *,
+        group: str = "",
+        attrs: Optional[Mapping[str, Any]] = None,
+    ) -> str:
         kwargs = {}
 
         if group:
@@ -16,7 +26,7 @@ class Publisher:
             kwargs["MessageDeduplicationId"] = str(uuid.uuid4())
 
         if attrs:
-            kwargs["MessageAttributes"] = attrs
+            kwargs["MessageAttributes"] = helpers.build_attributes(attrs)
 
         response = self.client.send_message(QueueUrl=recipient, MessageBody=message, **kwargs)
         return response["MessageId"]

--- a/cloud/google/pubsub.py
+++ b/cloud/google/pubsub.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Mapping, Optional
 
 from google.cloud import pubsub_v1
 
@@ -7,8 +7,17 @@ class Publisher:
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.client = pubsub_v1.PublisherClient(*args, **kwargs)
 
-    def publish(self, recipient: str, message: str, group: str = "", **attrs: Any) -> str:
-        future = self.client.publish(recipient, data=message.encode(), ordering_key=group, **attrs)
+    def publish(
+        self,
+        recipient: str,
+        message: str,
+        /,
+        *,
+        group: str = "",
+        attrs: Optional[Mapping[str, Any]] = None,
+    ) -> str:
+        kwargs = attrs or {}
+        future = self.client.publish(recipient, data=message.encode(), ordering_key=group, **kwargs)
         return future.result()
 
 

--- a/cloud/protocols.py
+++ b/cloud/protocols.py
@@ -1,4 +1,4 @@
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Mapping, Optional, Protocol, runtime_checkable
 
 
 @runtime_checkable
@@ -25,4 +25,12 @@ class StorageURLSigner(Protocol):
 
 @runtime_checkable
 class MessagePublisher(Protocol):
-    def publish(self, recipient: str, message: str, group: str = "", **attrs: Any) -> str: ...
+    def publish(
+        self,
+        recipient: str,
+        message: str,
+        /,
+        *,
+        group: str = "",
+        attrs: Optional[Mapping[str, Any]] = None,
+    ) -> str: ...

--- a/tests/amazon/test_sns.py
+++ b/tests/amazon/test_sns.py
@@ -2,6 +2,7 @@ import unittest
 import uuid
 from unittest import mock
 
+from cloud.amazon import helpers
 from cloud.amazon.sns import Publisher
 from cloud.protocols import MessagePublisher
 
@@ -43,13 +44,13 @@ class TestMessagePublisher(unittest.TestCase):
         topic = "arn:aws:sns:us-east-1:123456789012:test-topic"
         message = "test message"
         attributes = {"foo": "bar"}
-        message_id = publisher.publish(topic, message, **attributes)
+        message_id = publisher.publish(topic, message, attrs=attributes)
 
         self.assertEqual(message_id, response["MessageId"])
         self.client.publish.assert_called_once_with(
             TargetArn=topic,
             Message=message,
-            MessageAttributes=attributes,
+            MessageAttributes=helpers.build_attributes(attributes),
         )
 
     def test_publish_with_ordering(self):
@@ -67,7 +68,7 @@ class TestMessagePublisher(unittest.TestCase):
         deduplication_id = uuid.uuid4()
 
         with mock.patch("uuid.uuid4", lambda: deduplication_id):
-            message_id = publisher.publish(topic, message, group)
+            message_id = publisher.publish(topic, message, group=group)
 
         self.assertEqual(message_id, response["MessageId"])
         self.client.publish.assert_called_once_with(

--- a/tests/google/test_pubsub.py
+++ b/tests/google/test_pubsub.py
@@ -45,7 +45,7 @@ class TestMessagePublisher(unittest.TestCase):
         topic = "projects/test-project/topics/test-topic"
         message = "test message"
         attributes = {"foo": "bar"}
-        message_id = publisher.publish(topic, message, **attributes)
+        message_id = publisher.publish(topic, message, attrs=attributes)
 
         self.assertEqual(message_id, result)
         self.client.publish.assert_called_once_with(
@@ -68,7 +68,7 @@ class TestMessagePublisher(unittest.TestCase):
         topic = "projects/test-project/topics/test-topic"
         message = "test message"
         group = "test"
-        message_id = publisher.publish(topic, message, group)
+        message_id = publisher.publish(topic, message, group=group)
 
         self.assertEqual(message_id, result)
         self.client.publish.assert_called_once_with(


### PR DESCRIPTION
### Contain
- [x] Feature
- [x] Tests
- [x] Breaking changes

### Details
- Updated the `publish` method signatures across `sns`, `sqs`, and `pubsub` classes to use keyword-only arguments for `group` and `attrs`, improving clarity on parameter usage.
- Additionally, modified the way `MessageAttributes` are handled by integrating a helper function to build attributes, enhancing maintainability.
- The corresponding tests were also adjusted to reflect these changes, ensuring consistent behavior and proper functioning within the tests.